### PR TITLE
MapImageDumper Enhancements

### DIFF
--- a/source/net/openrs/cache/region/Region.java
+++ b/source/net/openrs/cache/region/Region.java
@@ -34,6 +34,9 @@ import net.openrs.util.ByteBufferUtils;
  */
 public class Region {
 
+	public static final int WIDTH = 64;
+	public static final int HEIGHT = 64;
+
 	private final int regionID;
 	private final int baseX;
 	private final int baseY;
@@ -56,7 +59,7 @@ public class Region {
 	/**
 	 * Decodes terrain data stored in the specified {@link ByteBuffer}.
 	 *
-	 * @param buffer
+	 * @param buf
 	 *            The ByteBuffer.
 	 */
 	public void loadTerrain(ByteBuffer buf) {
@@ -102,7 +105,7 @@ public class Region {
 	/**
 	 * Decodes location data stored in the specified {@link ByteBuffer}.
 	 *
-	 * @param buffer
+	 * @param buf
 	 *            The ByteBuffer.
 	 */
 	public void loadLocations(ByteBuffer buf) {

--- a/source/net/openrs/cache/region/Region.java
+++ b/source/net/openrs/cache/region/Region.java
@@ -197,8 +197,12 @@ public class Region {
 		return underlayIds[z][x][y] & 0xFF;
 	}
 
-	public final boolean isBridgeTile(final int z, final int x, final int y) {
-		return (getRenderRule(1, x, y) & 0x2) != 0;
+	public final boolean isLinkedBelow(final int z, final int x, final int y) {
+		return (getRenderRule(z, x, y) & 0x2) != 0;
+	}
+
+	public final boolean isVisibleBelow(final int z, final int x, final int y) {
+		return (getRenderRule(z, x, y) & 0x8) != 0;
 	}
 
 	/**

--- a/source/net/openrs/cache/region/Region.java
+++ b/source/net/openrs/cache/region/Region.java
@@ -196,7 +196,11 @@ public class Region {
 	public final int getUnderlayId(final int z, final int x, final int y) {
 		return underlayIds[z][x][y] & 0xFF;
 	}
-	
+
+	public final boolean isBridgeTile(final int z, final int x, final int y) {
+		return (getRenderRule(1, x, y) & 0x2) != 0;
+	}
+
 	/**
 	 * @return the locations
 	 */

--- a/source/net/openrs/cache/tools/MapImageDumper.java
+++ b/source/net/openrs/cache/tools/MapImageDumper.java
@@ -16,21 +16,6 @@
  */
 package net.openrs.cache.tools;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.Image;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import javax.imageio.ImageIO;
-
 import net.openrs.cache.Cache;
 import net.openrs.cache.Constants;
 import net.openrs.cache.Container;
@@ -46,420 +31,627 @@ import net.openrs.cache.type.objects.ObjectType;
 import net.openrs.cache.type.overlays.OverlayType;
 import net.openrs.cache.type.underlays.UnderlayType;
 import net.openrs.cache.util.XTEAManager;
+import net.openrs.util.BigBufferedImage;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by Kyle Fricilone on Sep 16, 2016.
  * Optimizations done by Adam
+ * Updated by Explv on October 02, 2018
  */
 public class MapImageDumper {
 
-	private final List<Region> regions = new ArrayList<>();
-	private final List<Integer> flags = new ArrayList<>();
-	
-	private final Map<Integer, Image> mapIcons = new HashMap<>();
-	
-	private Region lowestX;
-	private Region lowestY;
-	private Region highestX;
-	private Region highestY;
-	
-	private static final int MAX_REGION = 32768;
-	private static final int MAP_SCALE = 2;
-	
-	private static final boolean LABEL = true;
-	private static final boolean OUTLINE = true;
-	private static final boolean FILL = true;
-	
-	private void initialize(final Cache cache) throws IOException
-	{
-		TypeListManager.initialize(cache);
-		Textures.initialize(cache);
-		Sprites.initialize(cache);
-		XTEAManager.touch();
-		
-		for (int i = 0; i < MAX_REGION; i++)
-		{
-			final Region region = new Region(i);
-			
-			int map = cache.getFileId(5, region.getTerrainIdentifier());
-			int loc = cache.getFileId(5, region.getLocationsIdentifier());
-			if (map == -1 && loc == -1)
-				continue;
-			
-			if (map != -1)
-			{
-				region.loadTerrain(cache.read(5, map).getData());
-			}
-			
-			if (loc != -1)
-			{
-				ByteBuffer buffer = cache.getStore().read(5, loc);
-				try
-				{
-					region.loadLocations(Container.decode(buffer, XTEAManager.lookupMap(i)).getData());
-				}
-				
-				catch (Exception e)
-				{
-					if (buffer.limit() != 32)
-					{
-						flags.add(i);
-					}
-				}
-			}
-			
-			regions.add(region);
+    private static int[][] TILE_SHAPES = new int[][]{
+            {
+                    1, 1, 1, 1,
+                    1, 1, 1, 1,
+                    1, 1, 1, 1,
+                    1, 1, 1, 1
+            },
+            {
+                    1, 0, 0, 0,
+                    1, 1, 0, 0,
+                    1, 1, 1, 0,
+                    1, 1, 1, 1
+            },
 
-			if (lowestX == null || region.getBaseX() < lowestX.getBaseX())
-			{
-				lowestX = region;
-			}
+            {
+                    1, 1, 0, 0,
+                    1, 1, 0, 0,
+                    1, 0, 0, 0,
+                    1, 0, 0, 0
+            },
 
-			if (highestX == null || region.getBaseX() > highestX.getBaseX())
-			{
-				highestX = region;
-			}
+            {
+                    0, 0, 1, 1,
+                    0, 0, 1, 1,
+                    0, 0, 0, 1,
+                    0, 0, 0, 1,
+            },
+            {
+                    0, 1, 1, 1,
+                    0, 1, 1, 1,
+                    1, 1, 1, 1,
+                    1, 1, 1, 1
+            },
+            {
+                    1, 1, 1, 0,
+                    1, 1, 1, 0,
+                    1, 1, 1, 1,
+                    1, 1, 1, 1
+            },
+            {
+                    1, 1, 0, 0,
+                    1, 1, 0, 0,
+                    1, 1, 0, 0,
+                    1, 1, 0, 0
+            },
+            {
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    1, 0, 0, 0,
+                    1, 1, 0, 0
+            },
+            {
+                    1, 1, 1, 1,
+                    1, 1, 1, 1,
+                    0, 1, 1, 1,
+                    0, 0, 1, 1
+            },
+            {
+                    1, 1, 1, 1,
+                    1, 1, 0, 0,
+                    1, 0, 0, 0,
+                    1, 0, 0, 0
+            },
 
-			if (lowestY == null || region.getBaseY() < lowestY.getBaseY())
-			{
-				lowestY = region;
-			}
+            {
+                    0, 0, 0, 0,
+                    0, 0, 1, 1,
+                    0, 1, 1, 1,
+                    0, 1, 1, 1
+            },
 
-			if (highestY == null || region.getBaseY() > highestY.getBaseY())
-			{
-				highestY = region;
-			}
-			
-		}
-		
-		final Sprite mapscene = Sprites.getSprite("mapscene");
-		
-		for (int i = 0; i < mapscene.size(); i++)
-		{
-			mapIcons.put(i, mapscene.getFrame(i).getScaledInstance(4, 5, 0));
-		}
-	}
-	
-	private void draw() throws IOException
-	{
-		
-		int minX = lowestX.getBaseX();
-		int minY = lowestY.getBaseY();
+            {
+                    0, 0, 0, 0,
+                    0, 0, 0, 0,
+                    0, 1, 1, 0,
+                    1, 1, 1, 1
+            }
+    };
 
-		int maxX = highestX.getBaseX() + 64;
-		int maxY = highestY.getBaseY() + 64;
+    private static int[][] TILE_ROTATIONS = new int[][]{
+            {
+                    0, 1, 2, 3,
+                    4, 5, 6, 7,
+                    8, 9, 10, 11,
+                    12, 13, 14, 15
+            },
 
-		int dimX = maxX - minX;
-		int dimY = maxY - minY;
+            {
+                    12, 8, 4, 0,
+                    13, 9, 5, 1,
+                    14, 10, 6, 2,
+                    15, 11, 7, 3
+            },
 
-		int boundX = dimX - 1;
-		int boundY = dimY - 1;
-		
-		dimX *= MAP_SCALE;
-		dimY *= MAP_SCALE;
-		
-		BufferedImage baseImage = new BufferedImage(dimX, dimY, BufferedImage.TYPE_INT_RGB);
-		BufferedImage fullImage = new BufferedImage(dimX, dimY, BufferedImage.TYPE_INT_RGB);
-		
-		Graphics2D graphics = fullImage.createGraphics();
-		
-		//Draw Underlay Map - Pass 1
-		for (Region region : regions)
-		{
-			
-			int baseX = region.getBaseX();
-			int baseY = region.getBaseY();
-			int drawBaseX = baseX - lowestX.getBaseX();
-			int drawBaseY = highestY.getBaseY() - baseY;
-			
-			for (int x = 0; x < 64; ++x)
-			{
-				int drawX = drawBaseX + x;
+            {
+                    15, 14, 13, 12,
+                    11, 10, 9, 8,
+                    7, 6, 5, 4,
+                    3, 2, 1, 0
+            },
 
-				for (int y = 0; y < 64; ++y)
-				{
-					int drawY = drawBaseY + (63 - y);
+            {
+                    3, 7, 11, 15,
+                    2, 6, 10, 14,
+                    1, 5, 9, 13,
+                    0, 4, 8, 12
+            }
+    };
 
-					int overlayId = region.getOverlayId(0, x, y) - 1;
-					int underlayId = region.getUnderlayId(0, x, y) - 1;
-					int rgb = 0;
-					
-					if (overlayId > -1)
-					{
-						OverlayType overlay = TypeListManager.lookupOver(overlayId);
-						if (!overlay.isHideUnderlay() && underlayId > -1)
-						{
-							UnderlayType underlay = TypeListManager.lookupUnder(underlayId);
-							rgb = underlay.getRgbColor();
-						}
-						
-						else
-						{
-							rgb = Color.CYAN.getRGB();
-						}
-					}
-					
-					else if (underlayId > -1)
-					{
-						UnderlayType underlay = TypeListManager.lookupUnder(underlayId);
-						rgb = underlay.getRgbColor();
-					}
-					
-					else
-					{
-						rgb = Color.CYAN.getRGB();
-					}
+    private final List<Region> regions = new ArrayList<>();
+    private final List<Integer> flags = new ArrayList<>();
 
-					drawMapSquare(baseImage, drawX, drawY, rgb);
-				}
-			}
-		}
-		
-		//Blend Underlay Map - Pass 2
-		for (Region region : regions)
-		{
-			
-			int baseX = region.getBaseX();
-			int baseY = region.getBaseY();
-			int drawBaseX = baseX - lowestX.getBaseX();
-			int drawBaseY = highestY.getBaseY() - baseY;
-			
-			for (int x = 0; x < 64; ++x)
-			{
-				int drawX = drawBaseX + x;
+    private final Map<Integer, Image> mapIcons = new HashMap<>();
 
-				for (int y = 0; y < 64; ++y)
-				{
-					int drawY = drawBaseY + (63 - y);
+    private Region lowestX;
+    private Region lowestY;
+    private Region highestX;
+    private Region highestY;
 
-					Color c = getMapSquare(baseImage, drawX, drawY);
+    private static final int MAX_REGION = 32768;
+    private static final int PIXELS_PER_TILE = 4;
 
-					if (c.equals(Color.CYAN))
-						continue;
-					
-					int tRed = 0, tGreen = 0, tBlue = 0;
-					int count = 0;
-					
-					int maxDY = Math.min(boundY, drawY + 3);
-					int maxDX = Math.min(boundX, drawX + 3);
-					int minDY = Math.max(0, drawY - 3);
-					int minDX = Math.max(0, drawX - 3);
-					
-					
-					for (int dy = minDY; dy < maxDY; dy++)
-					{		
-						for (int dx = minDX; dx < maxDX; dx++)
-						{
-							c = getMapSquare(baseImage, dx, dy);
+    private static final boolean DRAW_WALLS = true;
+    private static final boolean DRAW_ICONS = true;
+    private static final boolean DRAW_REGIONS = true;
+    private static final boolean LABEL = true;
+    private static final boolean OUTLINE = true;
+    private static final boolean FILL = true;
 
-							if (c.equals(Color.CYAN))
-								continue;
+    private void initialize(final Cache cache) throws IOException {
+        TypeListManager.initialize(cache);
+        Textures.initialize(cache);
+        Sprites.initialize(cache);
+        XTEAManager.touch();
 
-							tRed += c.getRed();
-							tGreen += c.getGreen();
-							tBlue += c.getBlue();
-							count++;
-						}
-					}
+        for (int i = 0; i < MAX_REGION; i++) {
+            final Region region = new Region(i);
 
-					if (count > 0)
-					{
-						c = new Color(tRed / count, tGreen / count, tBlue / count);
-						drawMapSquare(fullImage, drawX, drawY, c.getRGB());
-					}
-				}
-			}
-		}
-		
-		//Draw Overlay Map - Pass 3
-		for (Region region : regions)
-		{
-			
-			int baseX = region.getBaseX();
-			int baseY = region.getBaseY();
-			int drawBaseX = baseX - lowestX.getBaseX();
-			int drawBaseY = highestY.getBaseY() - baseY;
-			
-			for (int x = 0; x < 64; ++x)
-			{
-				int drawX = drawBaseX + x;
+            int map = cache.getFileId(5, region.getTerrainIdentifier());
+            int loc = cache.getFileId(5, region.getLocationsIdentifier());
 
-				for (int y = 0; y < 64; ++y)
-				{
-					int drawY = drawBaseY + (63 - y);
+            if (map == -1 && loc == -1) {
+                continue;
+            }
 
-					int overlayId = region.getOverlayId(0, x, y) - 1;
-					int rgb = -1;
-					
-					if (overlayId > -1)
-					{
-						OverlayType overlay = TypeListManager.lookupOver(overlayId);
-						if (overlay.isHideUnderlay())
-						{
-							rgb = overlay.getRgbColor();
-						}
+            if (map != -1) {
+                region.loadTerrain(cache.read(5, map).getData());
+            }
 
-						
-						if (overlay.getSecondaryRgbColor() > -1)
-						{
-							rgb = overlay.getSecondaryRgbColor();
-						}
+            if (loc != -1) {
+                ByteBuffer buffer = cache.getStore().read(5, loc);
+                try {
+                    region.loadLocations(Container.decode(buffer, XTEAManager.lookupMap(i)).getData());
+                } catch (Exception e) {
+                    if (buffer.limit() != 32) {
+                        flags.add(i);
+                    }
+                }
+            }
 
-						
-						if (overlay.getTexture() > -1)
-						{
-							rgb = Textures.getColors(overlay.getTexture());
-						}
+            regions.add(region);
 
-					}
+            if (lowestX == null || region.getBaseX() < lowestX.getBaseX()) {
+                lowestX = region;
+            }
 
-					if (rgb > -1)
-						drawMapSquare(fullImage, drawX, drawY, rgb);
-				}
-			}
-		}
-		
-		//Draw Locations Map - Pass 4
-		for (Region region : regions)
-		{
-			
-			int baseX = region.getBaseX();
-			int baseY = region.getBaseY();
-			int drawBaseX = baseX - lowestX.getBaseX();
-			int drawBaseY = highestY.getBaseY() - baseY;
-			
-			for (Location location : region.getLocations())
-			{
-				if (location.getPosition().getHeight() != 0)
-				{
-				//	continue;
-				}
+            if (highestX == null || region.getBaseX() > highestX.getBaseX()) {
+                highestX = region;
+            }
 
-				ObjectType objType = TypeListManager.lookupObject(location.getId());
+            if (lowestY == null || region.getBaseY() < lowestY.getBaseY()) {
+                lowestY = region;
+            }
 
-				int localX = location.getPosition().getX() - region.getBaseX();
-				int localY = location.getPosition().getY() - region.getBaseY();
+            if (highestY == null || region.getBaseY() > highestY.getBaseY()) {
+                highestY = region;
+            }
 
-				int drawX = drawBaseX + localX;
-				int drawY = drawBaseY + (63 - localY);
+        }
 
-				if (objType.getMapSceneID() != -1)
-				{
-					Image spriteImage = mapIcons.get(objType.getMapSceneID());
-					graphics.drawImage(spriteImage, drawX * MAP_SCALE, drawY * MAP_SCALE, null);
-				}
-			}
-		}
-		
-		//Draw Icons Map - Pass 5
-		for (Region region : regions)
-		{
-			
-			int baseX = region.getBaseX();
-			int baseY = region.getBaseY();
-			int drawBaseX = baseX - lowestX.getBaseX();
-			int drawBaseY = highestY.getBaseY() - baseY;
-			
-			for (Location location : region.getLocations())
-			{
-				if (location.getPosition().getHeight() != 0)
-				{
-				//	continue;
-				}
+        final Sprite mapscene = Sprites.getSprite("mapscene");
 
-				ObjectType objType = TypeListManager.lookupObject(location.getId());
+        for (int i = 0; i < mapscene.size(); i++) {
+            mapIcons.put(i, mapscene.getFrame(i));
+        }
+    }
 
-				int localX = location.getPosition().getX() - region.getBaseX();
-				int localY = location.getPosition().getY() - region.getBaseY();
+    private void draw() throws IOException {
+        int minX = lowestX.getBaseX();
+        int minY = lowestY.getBaseY();
 
-				int drawX = drawBaseX + localX;
-				int drawY = drawBaseY + (63 - localY);
+        int maxX = highestX.getBaseX() + Region.WIDTH;
+        int maxY = highestY.getBaseY() + Region.HEIGHT;
 
-				if (objType.getMapAreaId() != -1)
-				{
-					AreaType areaType = TypeListManager.lookupArea(objType.getMapAreaId());
-					Image spriteImage = Sprites.getSprite(areaType.getSpriteId()).getFrame(0);
-					graphics.drawImage(spriteImage, (drawX - 1) * MAP_SCALE, (drawY - 1) * MAP_SCALE, null);
-				}
-			}
-		}
-		
-		//Label/Outline/Fill regions - Pass 6
-		for (Region region : regions)
-		{
-		
-			int baseX = region.getBaseX();
-			int baseY = region.getBaseY();
-			int drawBaseX = baseX - lowestX.getBaseX();
-			int drawBaseY = highestY.getBaseY() - baseY;
+        int dimX = maxX - minX;
+        int dimY = maxY - minY;
 
-			if (LABEL)
-			{
-				graphics.setColor(Color.RED);
-				graphics.drawString(String.valueOf(region.getRegionID()), drawBaseX * MAP_SCALE, drawBaseY * MAP_SCALE + graphics.getFontMetrics().getHeight());
-			}
+        int boundX = dimX - 1;
+        int boundY = dimY - 1;
 
-			if (OUTLINE)
-			{
-				graphics.setColor(Color.RED);
-				graphics.drawRect(drawBaseX * MAP_SCALE, drawBaseY * MAP_SCALE, 64 * MAP_SCALE, 64 * MAP_SCALE);
-			}
-			
-			if (FILL)
-			{
-				if (flags.contains(region.getRegionID()))
-				{
-					graphics.setColor(new Color(255, 0, 0, 80));
-					graphics.fillRect(drawBaseX * MAP_SCALE, drawBaseY * MAP_SCALE, 64 * MAP_SCALE, 64 * MAP_SCALE);
-				}
-			}
-			
-		}
-		
-		graphics.dispose();
-		
-		ImageIO.write(baseImage, "png", new File("base_image.png"));
-		ImageIO.write(fullImage, "png", new File("full_image.png"));
-	}
-	
-	private void drawMapSquare(BufferedImage image, int x, int y, int rgb)
-	{
-		x *= MAP_SCALE;
-		y *= MAP_SCALE;
+        dimX *= PIXELS_PER_TILE;
+        dimY *= PIXELS_PER_TILE;
 
-		for (int dx = 0; dx < MAP_SCALE; ++dx)
-		{
-			for (int dy = 0; dy < MAP_SCALE; ++dy)
-			{
-				image.setRGB(x + dx, y + dy, rgb);
-			}
-		}
-	}
-	
-	public Color getMapSquare(BufferedImage image, int x, int y)
-	{
-		x *= MAP_SCALE;
-		y *= MAP_SCALE;
-		
-		return new Color(image.getRGB(x, y));
-	}
-	
-	public static void main(String[] args)
-	{
-		long ms = System.currentTimeMillis();
-		MapImageDumper dumper = new MapImageDumper();
+        BufferedImage baseImage = BigBufferedImage.create(dimX, dimY, BufferedImage.TYPE_INT_RGB);
+        BufferedImage fullImage = BigBufferedImage.create(dimX, dimY, BufferedImage.TYPE_INT_RGB);
 
-		try (Cache cache = new Cache(FileStore.open(Constants.CACHE_PATH)))
-		{
-			dumper.initialize(cache);
-			dumper.draw();
-		}
-		
-		catch (Exception e)
-		{
-			e.printStackTrace();
-		}
-		System.out.println(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - ms));
-	}
-	
+        Graphics2D graphics = fullImage.createGraphics();
+
+        graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+
+        drawUnderlay(baseImage);
+        blendUnderlay(baseImage, fullImage, boundX, boundY);
+        drawOverlay(fullImage);
+        drawLocations(graphics);
+
+        if (DRAW_WALLS) {
+            drawWalls(graphics);
+        }
+
+        if (DRAW_ICONS) {
+            drawIcons(graphics);
+        }
+
+        if (DRAW_REGIONS) {
+            drawRegions(graphics);
+        }
+
+        graphics.dispose();
+
+        ImageIO.write(baseImage, "png", new File("base_image.png"));
+        ImageIO.write(fullImage, "png", new File("full_image.png"));
+    }
+
+    private void drawUnderlay(BufferedImage image) {
+        for (Region region : regions) {
+            int baseX = region.getBaseX();
+            int baseY = region.getBaseY();
+            int drawBaseX = baseX - lowestX.getBaseX();
+            int drawBaseY = highestY.getBaseY() - baseY;
+
+            for (int x = 0; x < Region.WIDTH; ++x) {
+                int drawX = drawBaseX + x;
+
+                for (int y = 0; y < Region.HEIGHT; ++y) {
+                    int drawY = drawBaseY + ((Region.HEIGHT - 1) - y);
+
+                    int underlayId = region.getUnderlayId(0, x, y) - 1;
+
+                    int rgb = Color.CYAN.getRGB();
+
+                    if (underlayId > -1) {
+                        UnderlayType underlay = TypeListManager.lookupUnder(underlayId);
+                        rgb = underlay.getRgbColor();
+                    }
+
+                    drawMapSquare(image, drawX, drawY, rgb, -1, -1);
+                }
+            }
+        }
+    }
+
+    private void blendUnderlay(BufferedImage baseImage, BufferedImage fullImage, int boundX, int boundY) {
+        for (Region region : regions) {
+            int baseX = region.getBaseX();
+            int baseY = region.getBaseY();
+            int drawBaseX = baseX - lowestX.getBaseX();
+            int drawBaseY = highestY.getBaseY() - baseY;
+
+            for (int x = 0; x < Region.WIDTH; ++x) {
+                int drawX = drawBaseX + x;
+
+                for (int y = 0; y < Region.HEIGHT; ++y) {
+                    int drawY = drawBaseY + ((Region.HEIGHT - 1) - y);
+
+                    Color c = getMapSquare(baseImage, drawX, drawY);
+
+                    if (c.equals(Color.CYAN)) {
+                        continue;
+                    }
+
+                    int tRed = 0, tGreen = 0, tBlue = 0;
+                    int count = 0;
+
+                    int maxDY = Math.min(boundY, drawY + 3);
+                    int maxDX = Math.min(boundX, drawX + 3);
+                    int minDY = Math.max(0, drawY - 3);
+                    int minDX = Math.max(0, drawX - 3);
+
+
+                    for (int dy = minDY; dy < maxDY; dy++) {
+                        for (int dx = minDX; dx < maxDX; dx++) {
+                            c = getMapSquare(baseImage, dx, dy);
+
+                            if (c.equals(Color.CYAN)) {
+                                continue;
+                            }
+
+                            tRed += c.getRed();
+                            tGreen += c.getGreen();
+                            tBlue += c.getBlue();
+                            count++;
+                        }
+                    }
+
+                    if (count > 0) {
+                        c = new Color(tRed / count, tGreen / count, tBlue / count);
+                        drawMapSquare(fullImage, drawX, drawY, c.getRGB(), -1, -1);
+                    }
+                }
+            }
+        }
+    }
+
+    private void drawOverlay(BufferedImage image) {
+        for (Region region : regions) {
+            int baseX = region.getBaseX();
+            int baseY = region.getBaseY();
+            int drawBaseX = baseX - lowestX.getBaseX();
+            int drawBaseY = highestY.getBaseY() - baseY;
+
+            for (int x = 0; x < Region.WIDTH; ++x) {
+                int drawX = drawBaseX + x;
+
+                for (int y = 0; y < Region.HEIGHT; ++y) {
+                    int drawY = drawBaseY + ((Region.HEIGHT - 1) - y);
+
+                    int overlayId = region.getOverlayId(0, x, y) - 1;
+                    int rgb = -1;
+
+                    if (overlayId > -1) {
+                        rgb = getOverLayColour(overlayId);
+                    }
+
+                    if (rgb > -1) {
+                        drawMapSquare(image, drawX, drawY, rgb, region.getOverlayPath(0, x, y), region.getOverlayRotation(0, x, y));
+                    }
+
+                    byte renderRule = region.getRenderRule(1, x, y);
+
+                    // If this is a bridge
+                    if ((renderRule & 0x2) != 0) {
+                        overlayId = region.getOverlayId(1, x, y) - 1;
+                        if (overlayId > -1) {
+                            rgb = getOverLayColour(overlayId);
+
+                            if (rgb > -1) {
+                                drawMapSquare(image, drawX, drawY, rgb, region.getOverlayPath(0, x, y), region.getOverlayRotation(0, x, y));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private int getOverLayColour(int overlayID) {
+        if (overlayID < 0) {
+            return -1;
+        }
+
+        OverlayType overlay = TypeListManager.lookupOver(overlayID);
+
+        int rgb = -1;
+
+        if (overlay.isHideUnderlay()) {
+            rgb = overlay.getRgbColor();
+        }
+
+
+        if (overlay.getSecondaryRgbColor() > -1) {
+            rgb = overlay.getSecondaryRgbColor();
+        }
+
+
+        if (overlay.getTexture() > -1) {
+            rgb = Textures.getColors(overlay.getTexture());
+        }
+
+        return rgb;
+    }
+
+    private void drawLocations(Graphics2D graphics) {
+        for (Region region : regions) {
+            int baseX = region.getBaseX();
+            int baseY = region.getBaseY();
+            int drawBaseX = baseX - lowestX.getBaseX();
+            int drawBaseY = highestY.getBaseY() - baseY;
+
+            for (Location location : region.getLocations()) {
+                int localX = location.getPosition().getX() - region.getBaseX();
+                int localY = location.getPosition().getY() - region.getBaseY();
+
+                if (location.getPosition().getHeight() != 0) {
+                    byte renderRule = region.getRenderRule(1, localX, localY);
+
+                    // If this is not a bridge
+                    if ((renderRule & 0x2) == 0) {
+                        continue;
+                    }
+                }
+
+                ObjectType objType = TypeListManager.lookupObject(location.getId());
+
+                int drawX = drawBaseX + localX;
+                int drawY = drawBaseY + ((Region.HEIGHT - 1) - localY);
+
+                if (objType.getMapSceneID() != -1) {
+                    Image spriteImage = mapIcons.get(objType.getMapSceneID());
+                    graphics.drawImage(spriteImage, drawX * PIXELS_PER_TILE, drawY * PIXELS_PER_TILE, null);
+                }
+            }
+        }
+    }
+
+    private void drawWalls(Graphics2D graphics) {
+        for (Region region : regions) {
+            int baseX = region.getBaseX();
+            int baseY = region.getBaseY();
+            int drawBaseX = baseX - lowestX.getBaseX();
+            int drawBaseY = highestY.getBaseY() - baseY;
+
+            for (Location location : region.getLocations()) {
+                graphics.setColor(Color.WHITE);
+
+                int localX = location.getPosition().getX() - region.getBaseX();
+                int localY = location.getPosition().getY() - region.getBaseY();
+
+                if (location.getPosition().getHeight() != 0) {
+                    byte renderRule = region.getRenderRule(location.getPosition().getHeight(), localX, localY);
+
+                    // If this is not a bridge
+                    if ((renderRule & 0x2) == 0) {
+                        continue;
+                    }
+                }
+
+                ObjectType objType = TypeListManager.lookupObject(location.getId());
+
+                // Don't draw walls on water
+                if (objType.getMapSceneID() == 22) {
+                    continue;
+                }
+
+                if (objType.getName().contains("Door")) {
+                    graphics.setColor(Color.RED);
+                }
+
+                int drawX = drawBaseX + localX;
+                int drawY = drawBaseY + ((Region.HEIGHT - 1) - localY);
+
+                drawX *= PIXELS_PER_TILE;
+                drawY *= PIXELS_PER_TILE;
+
+                if (location.getType() == 0) { // Straight walls
+                    if (location.getOrientation() == 0) { // West
+                        graphics.drawLine(drawX, drawY, drawX, drawY + PIXELS_PER_TILE);
+                    } else if (location.getOrientation() == 1) { // South
+                        graphics.drawLine(drawX, drawY, drawX + PIXELS_PER_TILE, drawY);
+                    } else if (location.getOrientation() == 2) { // East
+                        graphics.drawLine(drawX + PIXELS_PER_TILE, drawY, drawX + PIXELS_PER_TILE, drawY + PIXELS_PER_TILE);
+                    } else if (location.getOrientation() == 3) { // North
+                        graphics.drawLine(drawX, drawY + PIXELS_PER_TILE, drawX + PIXELS_PER_TILE, drawY + PIXELS_PER_TILE);
+                    }
+                } else if (location.getType() == 2) { // Corner walls
+                    if (location.getOrientation() == 0) { // West & South
+                        graphics.drawLine(drawX, drawY, drawX, drawY + PIXELS_PER_TILE);
+                        graphics.drawLine(drawX, drawY, drawX + PIXELS_PER_TILE, drawY);
+                    } else if (location.getOrientation() == 1) { // South & East
+                        graphics.drawLine(drawX, drawY, drawX + PIXELS_PER_TILE, drawY);
+                        graphics.drawLine(drawX + PIXELS_PER_TILE, drawY, drawX + PIXELS_PER_TILE, drawY + PIXELS_PER_TILE);
+                    } else if (location.getOrientation() == 2) { // East & North
+                        graphics.drawLine(drawX + PIXELS_PER_TILE, drawY, drawX + PIXELS_PER_TILE, drawY + PIXELS_PER_TILE);
+                        graphics.drawLine(drawX, drawY + PIXELS_PER_TILE, drawX + PIXELS_PER_TILE, drawY + PIXELS_PER_TILE);
+                    } else if (location.getOrientation() == 3) { // North & West
+                        graphics.drawLine(drawX, drawY + PIXELS_PER_TILE, drawX + PIXELS_PER_TILE, drawY + PIXELS_PER_TILE);
+                        graphics.drawLine(drawX, drawY, drawX, drawY + PIXELS_PER_TILE);
+                    }
+                } else if (location.getType() == 3) { // Single points
+                    if (location.getOrientation() == 0) { // West
+                        graphics.drawLine(drawX, drawY + 1, drawX, drawY + 1);
+                    } else if (location.getOrientation() == 1) { // South
+                        graphics.drawLine(drawX + 3, drawY + 1, drawX + 3, drawY + 1);
+                    } else if (location.getOrientation() == 2) { // East
+                        graphics.drawLine(drawX + 3, drawY + 4, drawX + 3, drawY + 4);
+                    } else if (location.getOrientation() == 3) { // North
+                        graphics.drawLine(drawX, drawY + 3, drawX, drawY + 3);
+                    }
+                } else if (location.getType() == 9) { // Diagonal walls
+                    if (location.getOrientation() == 0 || location.getOrientation() == 2) { // West or East
+                        graphics.drawLine(drawX, drawY + PIXELS_PER_TILE, drawX + PIXELS_PER_TILE, drawY);
+                    } else if (location.getOrientation() == 1 || location.getOrientation() == 3) { // South or South
+                        graphics.drawLine(drawX, drawY, drawX + PIXELS_PER_TILE, drawY + PIXELS_PER_TILE);
+                    }
+                }
+            }
+        }
+    }
+
+    private void drawIcons(Graphics2D graphics) {
+        for (Region region : regions) {
+            int baseX = region.getBaseX();
+            int baseY = region.getBaseY();
+            int drawBaseX = baseX - lowestX.getBaseX();
+            int drawBaseY = highestY.getBaseY() - baseY;
+
+            for (Location location : region.getLocations()) {
+                if (location.getPosition().getHeight() != 0) {
+                    continue;
+                }
+
+                ObjectType objType = TypeListManager.lookupObject(location.getId());
+
+                int localX = location.getPosition().getX() - region.getBaseX();
+                int localY = location.getPosition().getY() - region.getBaseY();
+
+                int drawX = drawBaseX + localX;
+                int drawY = drawBaseY + (63 - localY);
+
+                if (objType.getMapAreaId() != -1) {
+                    AreaType areaType = TypeListManager.lookupArea(objType.getMapAreaId());
+                    Image spriteImage = Sprites.getSprite(areaType.getSpriteId()).getFrame(0);
+                    graphics.drawImage(spriteImage, (drawX - 1) * PIXELS_PER_TILE, (drawY - 1) * PIXELS_PER_TILE, null);
+                }
+            }
+        }
+    }
+
+    private void drawRegions(Graphics2D graphics) {
+        for (Region region : regions) {
+            int baseX = region.getBaseX();
+            int baseY = region.getBaseY();
+            int drawBaseX = baseX - lowestX.getBaseX();
+            int drawBaseY = highestY.getBaseY() - baseY;
+
+            if (LABEL) {
+                graphics.setColor(Color.RED);
+                graphics.drawString(String.valueOf(region.getRegionID()), drawBaseX * PIXELS_PER_TILE, drawBaseY * PIXELS_PER_TILE + graphics.getFontMetrics().getHeight());
+            }
+
+            if (OUTLINE) {
+                graphics.setColor(Color.RED);
+                graphics.drawRect(drawBaseX * PIXELS_PER_TILE, drawBaseY * PIXELS_PER_TILE, 64 * PIXELS_PER_TILE, 64 * PIXELS_PER_TILE);
+            }
+
+            if (FILL) {
+                if (flags.contains(region.getRegionID())) {
+                    graphics.setColor(new Color(255, 0, 0, 80));
+                    graphics.fillRect(drawBaseX * PIXELS_PER_TILE, drawBaseY * PIXELS_PER_TILE, 64 * PIXELS_PER_TILE, 64 * PIXELS_PER_TILE);
+                }
+            }
+
+        }
+    }
+
+    private void drawMapSquare(BufferedImage image, int x, int y, int overlayRGB, int shape, int rotation) {
+        if (shape > -1) {
+            int[] shapeMatrix = TILE_SHAPES[shape];
+            int[] rotationMatrix = TILE_ROTATIONS[rotation & 0x3];
+            int shapeIndex = 0;
+            for (int tilePixelY = 0; tilePixelY < PIXELS_PER_TILE; tilePixelY++) {
+                for (int tilePixelX = 0; tilePixelX < PIXELS_PER_TILE; tilePixelX++) {
+                    int drawx = x * PIXELS_PER_TILE + tilePixelX;
+                    int drawy = y * PIXELS_PER_TILE + tilePixelY;
+
+                    if (shapeMatrix[rotationMatrix[shapeIndex++]] != 0) {
+                        image.setRGB(drawx, drawy, overlayRGB);
+                    }
+                }
+            }
+        } else {
+            for (int tilePixelY = 0; tilePixelY < PIXELS_PER_TILE; tilePixelY++) {
+                for (int tilePixelX = 0; tilePixelX < PIXELS_PER_TILE; tilePixelX++) {
+                    int drawx = x * PIXELS_PER_TILE + tilePixelX;
+                    int drawy = y * PIXELS_PER_TILE + tilePixelY;
+                    image.setRGB(drawx, drawy, overlayRGB);
+                }
+            }
+        }
+    }
+
+    public Color getMapSquare(BufferedImage image, int x, int y) {
+        x *= PIXELS_PER_TILE;
+        y *= PIXELS_PER_TILE;
+
+        return new Color(image.getRGB(x, y));
+    }
+
+    public static void main(String[] args) {
+        long ms = System.currentTimeMillis();
+        MapImageDumper dumper = new MapImageDumper();
+
+        try (Cache cache = new Cache(FileStore.open(Constants.CACHE_PATH))) {
+            dumper.initialize(cache);
+            dumper.draw();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        System.out.println(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - ms));
+    }
+
 }

--- a/source/net/openrs/util/BigBufferedImage.java
+++ b/source/net/openrs/util/BigBufferedImage.java
@@ -1,0 +1,300 @@
+package net.openrs.util;
+
+/*
+ * This class is part of MCFS (Mission Control - Flight Software) a development
+ * of Team Puli Space, official Google Lunar XPRIZE contestant.
+ * This class is released under Creative Commons CC0.
+ * @author Zsolt Pocze, Dimitry Polivaev
+ * Please like us on facebook, and/or join our Small Step Club.
+ * http://www.pulispace.com
+ * https://www.facebook.com/pulispace
+ * http://nyomdmegteis.hu/en/
+ */
+
+import sun.nio.ch.DirectBuffer;
+
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReadParam;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import java.awt.*;
+import java.awt.color.ColorSpace;
+import java.awt.image.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.*;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class BigBufferedImage extends BufferedImage {
+
+    private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+    public static final int MAX_PIXELS_IN_MEMORY =  1024 * 1024;
+
+    public static BufferedImage create(int width, int height, int imageType) {
+        if (width * height > MAX_PIXELS_IN_MEMORY) {
+            try {
+                final File tempDir = new File(TMP_DIR);
+                return createBigBufferedImage(tempDir, width, height, imageType);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return new BufferedImage(width, height, imageType);
+        }
+    }
+
+    public static BufferedImage create(File inputFile, int imageType) throws IOException {
+        try (ImageInputStream stream = ImageIO.createImageInputStream(inputFile);) {
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(stream);
+            if (readers.hasNext()) {
+                try {
+                    ImageReader reader = readers.next();
+                    reader.setInput(stream, true, true);
+                    int width = reader.getWidth(reader.getMinIndex());
+                    int height = reader.getHeight(reader.getMinIndex());
+                    BufferedImage image = create(width, height, imageType);
+                    int cores = Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
+                    int block = Math.min(MAX_PIXELS_IN_MEMORY / cores / width, (int) (Math.ceil(height / (double) cores)));
+                    ExecutorService generalExecutor = Executors.newFixedThreadPool(cores);
+                    List<Callable<ImagePartLoader>> partLoaders = new ArrayList<>();
+                    for (int y = 0; y < height; y += block) {
+                        partLoaders.add(new ImagePartLoader(
+                                y, width, Math.min(block, height - y), inputFile, image));
+                    }
+                    generalExecutor.invokeAll(partLoaders);
+                    generalExecutor.shutdown();
+                    return image;
+                } catch (InterruptedException ex) {
+                    Logger.getLogger(BigBufferedImage.class.getName()).log(Level.SEVERE, null, ex);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static BufferedImage createBigBufferedImage(File tempDir, int width, int height, int imageType)
+            throws FileNotFoundException, IOException {
+        FileDataBuffer buffer = new FileDataBuffer(tempDir, width * height, 4);
+        ColorModel colorModel = null;
+        BandedSampleModel sampleModel = null;
+        switch (imageType) {
+            case TYPE_INT_RGB:
+                colorModel = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_sRGB),
+                        new int[]{8, 8, 8, 0},
+                        false,
+                        false,
+                        ComponentColorModel.TRANSLUCENT,
+                        DataBuffer.TYPE_BYTE);
+                sampleModel = new BandedSampleModel(DataBuffer.TYPE_BYTE, width, height, 3);
+                break;
+            case TYPE_INT_ARGB:
+                colorModel = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_sRGB),
+                        new int[]{8, 8, 8, 8},
+                        true,
+                        false,
+                        ComponentColorModel.TRANSLUCENT,
+                        DataBuffer.TYPE_BYTE);
+                sampleModel = new BandedSampleModel(DataBuffer.TYPE_BYTE, width, height, 4);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported image type: " + imageType);
+        }
+        SimpleRaster raster = new SimpleRaster(sampleModel, buffer, new Point(0, 0));
+        BigBufferedImage image = new BigBufferedImage(colorModel, raster, colorModel.isAlphaPremultiplied(), null);
+        return image;
+    }
+
+    private static class ImagePartLoader implements Callable<ImagePartLoader> {
+
+        private final int y;
+        private final BufferedImage image;
+        private final Rectangle region;
+        private final File file;
+
+        public ImagePartLoader(int y, int width, int height, File file, BufferedImage image) {
+            this.y = y;
+            this.image = image;
+            this.file = file;
+            region = new Rectangle(0, y, width, height);
+        }
+
+        @Override
+        public ImagePartLoader call() throws Exception {
+            Thread.currentThread().setPriority((Thread.MIN_PRIORITY + Thread.NORM_PRIORITY) / 2);
+            try (ImageInputStream stream = ImageIO.createImageInputStream(file);) {
+                Iterator<ImageReader> readers = ImageIO.getImageReaders(stream);
+                if (readers.hasNext()) {
+                    ImageReader reader = readers.next();
+                    reader.setInput(stream, true, true);
+                    ImageReadParam param = reader.getDefaultReadParam();
+                    param.setSourceRegion(region);
+                    BufferedImage part = reader.read(0, param);
+                    Raster source = part.getRaster();
+                    WritableRaster target = image.getRaster();
+                    target.setRect(0, y, source);
+                }
+            }
+            return ImagePartLoader.this;
+        }
+    }
+
+    private BigBufferedImage(ColorModel cm, SimpleRaster raster, boolean isRasterPremultiplied, Hashtable<?, ?> properties) {
+        super(cm, raster, isRasterPremultiplied, properties);
+    }
+
+    public void dispose() {
+        ((SimpleRaster) getRaster()).dispose();
+    }
+
+    public static void dispose(RenderedImage image) {
+        if (image instanceof BigBufferedImage) {
+            ((BigBufferedImage) image).dispose();
+        }
+    }
+
+    private static class SimpleRaster extends WritableRaster {
+
+        public SimpleRaster(SampleModel sampleModel, FileDataBuffer dataBuffer, Point origin) {
+            super(sampleModel, dataBuffer, origin);
+        }
+
+        public void dispose() {
+            ((FileDataBuffer) getDataBuffer()).dispose();
+        }
+
+    }
+
+    private static final class FileDataBufferDeleterHook extends Thread {
+
+        static {
+            Runtime.getRuntime().addShutdownHook(new FileDataBufferDeleterHook());
+        }
+
+        private static final HashSet<FileDataBuffer> undisposedBuffers = new HashSet<>();
+
+        @Override
+        public void run() {
+            final FileDataBuffer[] buffers = undisposedBuffers.toArray(new FileDataBuffer[0]);
+            for (FileDataBuffer b : buffers) {
+                b.disposeNow();
+            }
+        }
+    }
+
+    private static class FileDataBuffer extends DataBuffer {
+
+        private final String id = "buffer-" + System.currentTimeMillis() + "-" + ((int) (Math.random() * 1000));
+        private File dir;
+        private String path;
+        private File[] files;
+        private RandomAccessFile[] accessFiles;
+        private MappedByteBuffer[] buffer;
+
+        public FileDataBuffer(File dir, int size) throws FileNotFoundException, IOException {
+            super(TYPE_BYTE, size);
+            this.dir = dir;
+            init();
+        }
+
+        public FileDataBuffer(File dir, int size, int numBanks) throws FileNotFoundException, IOException {
+            super(TYPE_BYTE, size, numBanks);
+            this.dir = dir;
+            init();
+        }
+
+        private void init() throws FileNotFoundException, IOException {
+            FileDataBufferDeleterHook.undisposedBuffers.add(this);
+            if (dir == null) {
+                dir = new File(".");
+            }
+            if (!dir.exists()) {
+                throw new RuntimeException("FileDataBuffer constructor parameter dir does not exist: " + dir);
+            }
+            if (!dir.isDirectory()) {
+                throw new RuntimeException("FileDataBuffer constructor parameter dir is not a directory: " + dir);
+            }
+            path = dir.getPath() + "/" + id;
+            File subDir = new File(path);
+            subDir.mkdir();
+            buffer = new MappedByteBuffer[banks];
+            accessFiles = new RandomAccessFile[banks];
+            files = new File[banks];
+            for (int i = 0; i < banks; i++) {
+                File file = files[i] = new File(path + "/bank" + i + ".dat");
+                final RandomAccessFile randomAccessFile = accessFiles[i] = new RandomAccessFile(file, "rw");
+                buffer[i] = randomAccessFile.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, getSize());
+            }
+        }
+
+        @Override
+        public int getElem(int bank, int i) {
+            return buffer[bank].get(i) & 0xff;
+        }
+
+        @Override
+        public void setElem(int bank, int i, int val) {
+            buffer[bank].put(i, (byte) val);
+        }
+
+        @Override
+        protected void finalize() throws Throwable {
+            dispose();
+        }
+
+        private void disposeNow() {
+            final MappedByteBuffer[] disposedBuffer = this.buffer;
+            this.buffer = null;
+            disposeNow(disposedBuffer);
+        }
+
+        public void dispose() {
+            final MappedByteBuffer[] disposedBuffer = this.buffer;
+            this.buffer = null;
+            new Thread() {
+                @Override
+                public void run() {
+                    disposeNow(disposedBuffer);
+                }
+            }.start();
+        }
+
+        private void disposeNow(final MappedByteBuffer[] disposedBuffer) {
+            FileDataBufferDeleterHook.undisposedBuffers.remove(this);
+            if (disposedBuffer != null) {
+                for (MappedByteBuffer b : disposedBuffer) {
+                    ((DirectBuffer) b).cleaner().clean();
+                }
+            }
+            if (accessFiles != null) {
+                for (RandomAccessFile file : accessFiles) {
+                    try {
+                        file.close();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+                accessFiles = null;
+            }
+            if (files != null) {
+                for (File file : files) {
+                    file.delete();
+                }
+                files = null;
+            }
+            if (path != null) {
+                new File(path).delete();
+                path = null;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
- Map is now drawn at a resolution of 4px<sup>2</sup> per tile
- BigBufferedImage is used to avoid running out of memory
- Tile shapes are utilised to produce a more accurate map
- Walls and doors are now drawn
- Bridges drawn
- Map images generated for plane 0 - 3, instead of just 0

Example image:

![full_image_example](https://user-images.githubusercontent.com/15495425/46383699-9e281600-c6a9-11e8-91ee-1692b1ef8d62.png)


